### PR TITLE
PE-698 - Adding option to skip table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ positional arguments:
                         
                         time_asset <course_id> ...   : Update time_on_asset_daily and time_on_asset_totals tables of data on time on asset (ie module_id,
                                                        aka url_name), based on daily tracking logs, for specified course.
+                                                       This command accepts --skip-total-assets-table, if provided, the command will only create the table called: time_on_asset_daily.
                         
                         item_tables <course_id> ... : Make course_item and person_item tables, used for IRT analyses.
                         

--- a/edx2bigquery/main.py
+++ b/edx2bigquery/main.py
@@ -438,6 +438,9 @@ def time_on_asset(param, course_id, optargs=None, skip_totals=False, just_do_tot
 
     import make_time_on_asset
 
+    if not skip_totals:
+        skip_totals = param.skip_total_assets_table
+
     try:
         make_time_on_asset.process_course_time_on_asset(course_id,
                                                         force_recompute=param.force_recompute,
@@ -1872,6 +1875,7 @@ check_for_duplicates        : check list of courses for duplicates
     parser.add_argument('courses', nargs = '*', help = 'courses or course directories, depending on the command')
     parser.add_argument('--use-local-tracking-files', help='Use the local tracking log files to upload into BigQuery instead of Google Cloud Storage files.', action="store_true")
     parser.add_argument('--split-multiple-files', help='Split multiples files for the same date.', action="store_true")
+    parser.add_argument("--skip-total-assets-table", help="For time_asset command, if provided, the command will only create the table called: time_on_asset_daily", action="store_true")
 
     args = parser.parse_args()
     if args.verbose:
@@ -1903,6 +1907,7 @@ check_for_duplicates        : check list of courses for duplicates
     param.subsection = args.subsection
     param.use_local_files = args.use_local_tracking_files
     param.split_multiple_files = args.split_multiple_files
+    param.skip_total_assets_table = args.skip_total_assets_table
 
     # default end date for person_course
     try:

--- a/edx2bigquery/make_time_on_asset.py
+++ b/edx2bigquery/make_time_on_asset.py
@@ -107,6 +107,8 @@ def process_course_time_on_asset(course_id, force_recompute=False, use_dataset_l
           """
 
     table = 'time_on_asset_daily'
+    dataset_name = bqutil.course_id2dataset(course_id)
+    bqutil.create_dataset_if_nonexistent(dataset_name)
 
     def gdf(row):
         return datetime.datetime.strptime(row['date'], '%Y-%m-%d')


### PR DESCRIPTION
## Description:

This PR adds a new command option called: --skip-total-assets-table to skip the creation of the table called: time_on_asset_totals.
This new option is intended to be used by calling the time_asset command.

## Reviewers:

- [ ] @andrey-canon 